### PR TITLE
Added the skeleton for the PCF8574 component

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Build ${{ matrix.example_path }}
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: "latest" # latest is the default version
+          esp_idf_version: "release/v5.5"
           target: ${{ matrix.espidf_target }}
           path: ${{ matrix.example_path }}

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Build ${{ matrix.example_path }}
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: "release/v5.5"
+          esp_idf_version: v5.5.3
           target: ${{ matrix.espidf_target }}
           path: ${{ matrix.example_path }}

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -16,14 +16,17 @@ jobs:
       matrix:
         espidf_target:
           - esp32c3
+        example_path:
+          - 'examples/basic'
+          - 'examples/pcf8574_input'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - name: Build Test Application with ESP-IDF
+      - name: Build ${{ matrix.example_path }}
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: "latest" # latest is the default version
           target: ${{ matrix.espidf_target }}
-          path: 'examples/basic'
+          path: ${{ matrix.example_path }}

--- a/.github/workflows/upload_components.yml
+++ b/.github/workflows/upload_components.yml
@@ -15,6 +15,6 @@ jobs:
         uses: espressif/upload-components-ci-action@v1
         with:
           directories: >
-            components/vibramotor;bsp/hope-badge;
+            components/vibramotor;bsp/hope-badge;components/pcf8574
           namespace: "hope-badge"
           api_token: ${{ secrets.CM_TOKEN }}

--- a/bsp/hope-badge/README.md
+++ b/bsp/hope-badge/README.md
@@ -38,7 +38,8 @@ This is the HOPE Badge Board Support Package, which is configurable from `menuco
 | max17048    |[espressif/max17048](https://components.espressif.com/components/espressif/max17048)                          |
 | i2c_bus     |[espressif/i2c_bus](https://components.espressif.com/components/espressif/i2c_bus)                            |
 | ir_learn    |[espressif/ir_learn](https://components.espressif.com/components/espressif/ir_learn)                          |
-| vibramotor  |[hope-badge/vibramotor](https://components.espressif.com/components/hope-badge/vibramotor)                                                                |
+| vibramotor  |[hope-badge/vibramotor](https://components.espressif.com/components/hope-badge/vibramotor)                    |
+| pcf8574     |                                                                                                              |
 
 ## How to use
 

--- a/bsp/hope-badge/idf_component.yml
+++ b/bsp/hope-badge/idf_component.yml
@@ -21,6 +21,10 @@ dependencies:
     version: '*'
     override_path: ../../components/vibramotor
 
+  hope-badge/pcf8574:
+    version: '*'
+    override_path: ../../components/pcf8574
+
   button:
     version: "^4"
     public: true

--- a/bsp/hope-badge/idf_component.yml
+++ b/bsp/hope-badge/idf_component.yml
@@ -15,7 +15,7 @@ tags:
   - badge
 
 dependencies:
-  idf: ">=5.3"
+  idf: ">=5.4"
 
   hope-badge/vibramotor:
     version: '*'
@@ -39,10 +39,6 @@ dependencies:
 
   i2c_bus:
     version: "^1.1.*"
-    public: true
-
-  ir_learn:
-    version: "^1.0.0"
     public: true
 
 examples:

--- a/bsp/hope-badge/include/bsp/bsp_hope.h
+++ b/bsp/hope-badge/include/bsp/bsp_hope.h
@@ -7,6 +7,7 @@
 #include "iot_button.h"
 #include "led_strip.h"
 #include "max17048.h"
+#include "pcf8574.h"
 
 /**************************************************************************************************
  *  BSP Capabilities
@@ -234,6 +235,32 @@ float bsp_get_battery_percentage(void);
  *      - Returns -1.0f on error
  */
 float bsp_get_battery_voltage(void);
+
+/**************************************************************************************************
+ *
+ * PCF8574
+ *
+ **************************************************************************************************/
+
+/** * @brief Initialize the PCF8574 I/O expander
+ * * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   PCF8574 parameter error
+ *      - ESP_FAIL              PCF8574 initialization error
+ */
+esp_err_t bsp_pcf8574_init(void);
+
+/**
+ * @brief Read the state of the PCF8574 I/O expander
+ *
+ * @param data Pointer to store the read data
+ *
+ * @return
+ *      - ESP_OK                On success
+ *      - ESP_ERR_INVALID_ARG   PCF8574 handle or data pointer is NULL
+ *      - ESP_FAIL              Read operation failed
+ */
+esp_err_t bsp_pcf8574_read_ios(uint8_t *data);
 
 #ifdef __cplusplus
 }

--- a/bsp/hope-badge/include/bsp/bsp_hope.h
+++ b/bsp/hope-badge/include/bsp/bsp_hope.h
@@ -253,6 +253,15 @@ float bsp_get_battery_voltage(void);
 esp_err_t bsp_pcf8574_init(void);
 
 /**
+ * @brief Get the PCF8574 device handle
+ *
+ * @return
+ *      - PCF8574 handle if initialized
+ *      - NULL if not initialized
+ */
+pcf8574_handle_t bsp_pcf8574_get_handle(void);
+
+/**
  * @brief Read the state of the PCF8574 I/O expander
  *
  * @param data Pointer to store the read data

--- a/bsp/hope-badge/include/bsp/bsp_hope.h
+++ b/bsp/hope-badge/include/bsp/bsp_hope.h
@@ -242,8 +242,10 @@ float bsp_get_battery_voltage(void);
  *
  **************************************************************************************************/
 
-/** * @brief Initialize the PCF8574 I/O expander
- * * @return
+/**
+ * @brief Initialize the PCF8574 I/O expander
+ *
+ * @return
  *      - ESP_OK                On success
  *      - ESP_ERR_INVALID_ARG   PCF8574 parameter error
  *      - ESP_FAIL              PCF8574 initialization error

--- a/bsp/hope-badge/src/bsp_hope.c
+++ b/bsp/hope-badge/src/bsp_hope.c
@@ -26,6 +26,7 @@ static bool i2c_initialized = false;
 static button_handle_t btn[BSP_BUTTON_NUM] = {NULL};
 static led_strip_handle_t led_rgb_handle = NULL;
 static max17048_handle_t max17048 = NULL;
+static pcf8574_handle_t pcf_dev = NULL;
 
 esp_err_t bsp_i2c_init(void)
 {
@@ -275,6 +276,26 @@ esp_err_t bsp_fuel_gauge_init(void)
     return ESP_OK;
 }
 
+esp_err_t bsp_pcf8574_init(void)
+{
+
+    pcf_dev = pcf8574_create(i2c_bus, PCF8574_I2C_ADDR_DEFAULT);
+    if (pcf_dev == NULL) {
+        ESP_LOGE(TAG, "Failed to create PCF8574 handle");
+        return ESP_FAIL;
+    }
+
+    // Set as output
+    uint8_t io_dir_mask = 0x0E;  // 00001110 -> P3, P2, P1 = 1 (entrada)
+    pcf8574_write(pcf_dev, io_dir_mask);
+
+    ESP_LOGI(TAG, "PCF8574 initialized successfully");
+
+    
+
+    return ESP_OK;
+}
+
 esp_err_t bsp_init(void)
 {
     ESP_LOGI(TAG, "Initializing Hope Badge BSP");
@@ -308,6 +329,9 @@ esp_err_t bsp_init(void)
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to initialize fuel gauge: %s", esp_err_to_name(ret));
     }
+
+    // Only initialize PCF8574 if it is used in the project
+    bsp_pcf8574_init();
 
     ESP_LOGI(TAG, "BSP initialization complete");
 

--- a/bsp/hope-badge/src/bsp_hope.c
+++ b/bsp/hope-badge/src/bsp_hope.c
@@ -286,7 +286,7 @@ esp_err_t bsp_pcf8574_init(void)
     }
 
     // Set as output
-    uint8_t io_dir_mask = 0x0E;  // 00001110 -> P3, P2, P1 = 1 (entrada)
+    uint8_t io_dir_mask = 0x0E;  // 00001110 -> P3, P2, P1 = 1 (input)
     pcf8574_write(pcf_dev, io_dir_mask);
 
     ESP_LOGI(TAG, "PCF8574 initialized successfully");

--- a/bsp/hope-badge/src/bsp_hope.c
+++ b/bsp/hope-badge/src/bsp_hope.c
@@ -278,22 +278,30 @@ esp_err_t bsp_fuel_gauge_init(void)
 
 esp_err_t bsp_pcf8574_init(void)
 {
-
     pcf_dev = pcf8574_create(i2c_bus, PCF8574_I2C_ADDR_DEFAULT);
     if (pcf_dev == NULL) {
         ESP_LOGE(TAG, "Failed to create PCF8574 handle");
         return ESP_FAIL;
     }
 
-    // Set as output
-    uint8_t io_dir_mask = 0x0E;  // 00001110 -> P3, P2, P1 = 1 (input)
-    pcf8574_write(pcf_dev, io_dir_mask);
+    // Set direction: P1, P2, P3 as inputs (weak pull-up), rest as outputs
+    uint8_t io_dir_mask = 0x0E;  // 00001110 -> P3, P2, P1 = input
+    esp_err_t ret = pcf8574_set_direction(pcf_dev, io_dir_mask);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set PCF8574 direction: %s", esp_err_to_name(ret));
+        return ret;
+    }
 
     ESP_LOGI(TAG, "PCF8574 initialized successfully");
-
-    
-
     return ESP_OK;
+}
+
+pcf8574_handle_t bsp_pcf8574_get_handle(void)
+{
+    if (pcf_dev == NULL) {
+        ESP_LOGE(TAG, "PCF8574 handle is not initialized");
+    }
+    return pcf_dev;
 }
 
 esp_err_t bsp_init(void)

--- a/components/pcf8574/CMakeLists.txt
+++ b/components/pcf8574/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SRCS src/*.c)
 idf_component_register(
     SRCS ${SRCS}
     INCLUDE_DIRS "include"
-    REQUIRES driver
+    REQUIRES i2c_bus
 )

--- a/components/pcf8574/CMakeLists.txt
+++ b/components/pcf8574/CMakeLists.txt
@@ -3,5 +3,5 @@ file(GLOB_RECURSE SRCS src/*.c)
 idf_component_register(
     SRCS ${SRCS}
     INCLUDE_DIRS "include"
-    REQUIRES i2c_bus
+    REQUIRES driver i2c_bus
 )

--- a/components/pcf8574/CMakeLists.txt
+++ b/components/pcf8574/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB_RECURSE SRCS src/*.c)
+
+idf_component_register(
+    SRCS ${SRCS}
+    INCLUDE_DIRS "include"
+    REQUIRES driver
+)

--- a/components/pcf8574/LICENSE
+++ b/components/pcf8574/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/components/pcf8574/README.md
+++ b/components/pcf8574/README.md
@@ -1,0 +1,9 @@
+# PCF8574 I²C I/O Expander Driver for ESP-IDF
+
+This component provides a simple interface to interact with the **PCF8574** 8-bit I²C I/O expander using the [i2c_bus](https://github.com/espressif/esp-iot-solution/tree/master/components/i2c_bus) abstraction from Espressif's IoT Solution.
+
+## ✅ Features
+
+- Supports reading and writing 8-bit I/O data
+- Built on top of `i2c_bus` for clean and reusable I²C access
+- Lightweight and easy to integrate into existing projects

--- a/components/pcf8574/idf_component.yml
+++ b/components/pcf8574/idf_component.yml
@@ -1,12 +1,14 @@
-version: "0.0.2"
-description: Vibramotor component for the HOPE badge
+name: hope-badge/pcf8574
+version: "0.0.1"
+description: PCF8574 I2C GPIO Expander Component
 url: https://github.com/hope-badge/esp-idf-bsp
 repository: https://github.com/hope-badge/esp-idf-bsp.git
 issues: https://github.com/hope-badge/esp-idf-bsp/issues
 
 tags:
-  - motor
-  - vibramotor
+  - pcf8574
+  - gpio
 
 dependencies:
+  i2c_bus: "^1.1.0"
   idf: ">=5.1"

--- a/components/pcf8574/include/pcf8574.h
+++ b/components/pcf8574/include/pcf8574.h
@@ -1,12 +1,21 @@
 /**
  * @file
  * @brief PCF8574 I2C GPIO Expander Driver
+ *
+ * Driver for the NXP PCF8574/PCF8574A 8-bit I2C I/O expander.
+ * Supports full byte and individual pin read/write, pin direction
+ * configuration, and interrupt-driven pin change notification.
+ *
+ * The PCF8574 has quasi-bidirectional I/O: pins written HIGH have a
+ * weak internal pull-up (~100 µA) and can be used as inputs.
  */
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "esp_err.h"
+#include "driver/gpio.h"
 #include "sdkconfig.h"
 #include "i2c_bus.h"
 
@@ -14,7 +23,9 @@
 extern "C" {
 #endif
 
-#define PCF8574_I2C_ADDR_DEFAULT 0x20
+#define PCF8574_I2C_ADDR_DEFAULT    0x20    /*!< Default I2C address for PCF8574 (A2=A1=A0=0) */
+#define PCF8574A_I2C_ADDR_DEFAULT   0x38    /*!< Default I2C address for PCF8574A (A2=A1=A0=0) */
+#define PCF8574_PIN_COUNT           8       /*!< Number of I/O pins on the PCF8574 */
 
 /**
  * @brief PCF8574 device handle type (opaque pointer)
@@ -22,7 +33,24 @@ extern "C" {
 typedef void *pcf8574_handle_t;
 
 /**
+ * @brief Callback type for PCF8574 interrupt events.
+ *
+ * Called from ISR context when the INT pin fires. Keep the handler short
+ * and defer heavy work to a task (e.g., via xTaskNotifyFromISR).
+ *
+ * @param arg User-supplied argument passed during registration
+ */
+typedef void (*pcf8574_int_cb_t)(void *arg);
+
+/*******************************************************************************
+ * Lifecycle
+ ******************************************************************************/
+
+/**
  * @brief Create and initialize a PCF8574 device on the given I2C bus.
+ *
+ * All pins default to HIGH (input-ready with weak pull-up) after creation,
+ * matching the PCF8574 power-on state.
  *
  * @param bus I2C bus handle
  * @param dev_addr 7-bit I2C device address
@@ -33,11 +61,17 @@ pcf8574_handle_t pcf8574_create(i2c_bus_handle_t bus, uint8_t dev_addr);
 /**
  * @brief Delete a PCF8574 device and free associated resources.
  *
+ * If an interrupt was registered, it will be unregistered automatically.
+ *
  * @param[in,out] dev Pointer to the device handle. Will be set to NULL on success.
  * @return
  *      - ESP_OK on success
  */
 esp_err_t pcf8574_delete(pcf8574_handle_t *dev);
+
+/*******************************************************************************
+ * Full-byte I/O
+ ******************************************************************************/
 
 /**
  * @brief Read the current 8-bit pin state from the PCF8574.
@@ -54,6 +88,9 @@ esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data);
 /**
  * @brief Write an 8-bit value to the PCF8574 output pins.
  *
+ * Updates the internal output cache. Input pins (direction mask = 1)
+ * are forced HIGH automatically.
+ *
  * @param dev Device handle
  * @param data The byte to write to the output pins
  * @return
@@ -62,6 +99,135 @@ esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data);
  *      - ESP_FAIL on I2C write error
  */
 esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data);
+
+/*******************************************************************************
+ * Pin direction
+ ******************************************************************************/
+
+/**
+ * @brief Set the I/O direction for all 8 pins.
+ *
+ * Bits set to 1 in @p input_mask are configured as inputs (written HIGH
+ * to enable the weak pull-up). Bits set to 0 are configured as outputs.
+ * Output pins retain their last written value.
+ *
+ * @param dev Device handle
+ * @param input_mask Bitmask where 1 = input, 0 = output (e.g., 0x0F = P0-P3 input)
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev is NULL
+ *      - ESP_FAIL on I2C write error
+ */
+esp_err_t pcf8574_set_direction(pcf8574_handle_t dev, uint8_t input_mask);
+
+/**
+ * @brief Get the current direction mask.
+ *
+ * @param dev Device handle
+ * @param[out] input_mask Pointer to store current direction mask (1 = input)
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev or input_mask is NULL
+ */
+esp_err_t pcf8574_get_direction(pcf8574_handle_t dev, uint8_t *input_mask);
+
+/*******************************************************************************
+ * Individual pin operations
+ ******************************************************************************/
+
+/**
+ * @brief Set a single pin HIGH.
+ *
+ * Uses the cached output state to avoid an I2C read.
+ *
+ * @param dev Device handle
+ * @param pin Pin number (0–7)
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev is NULL or pin > 7
+ *      - ESP_FAIL on I2C write error
+ */
+esp_err_t pcf8574_set_pin(pcf8574_handle_t dev, uint8_t pin);
+
+/**
+ * @brief Set a single pin LOW.
+ *
+ * Uses the cached output state to avoid an I2C read.
+ *
+ * @param dev Device handle
+ * @param pin Pin number (0–7)
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev is NULL or pin > 7
+ *      - ESP_FAIL on I2C write error
+ */
+esp_err_t pcf8574_clear_pin(pcf8574_handle_t dev, uint8_t pin);
+
+/**
+ * @brief Toggle a single pin.
+ *
+ * Uses the cached output state to avoid an I2C read.
+ *
+ * @param dev Device handle
+ * @param pin Pin number (0–7)
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev is NULL or pin > 7
+ *      - ESP_FAIL on I2C write error
+ */
+esp_err_t pcf8574_toggle_pin(pcf8574_handle_t dev, uint8_t pin);
+
+/**
+ * @brief Read the level of a single pin.
+ *
+ * Performs an I2C read to get the actual pin state.
+ *
+ * @param dev Device handle
+ * @param pin Pin number (0–7)
+ * @param[out] level Pointer to store the pin level (0 or 1)
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev or level is NULL, or pin > 7
+ *      - ESP_FAIL on I2C read error
+ */
+esp_err_t pcf8574_read_pin(pcf8574_handle_t dev, uint8_t pin, uint8_t *level);
+
+/*******************************************************************************
+ * Interrupt support
+ ******************************************************************************/
+
+/**
+ * @brief Register an interrupt handler for PCF8574 pin-change events.
+ *
+ * The PCF8574 INT pin is active-LOW, open-drain. This function configures
+ * the specified host GPIO with a falling-edge ISR that calls @p callback.
+ *
+ * @note Only one interrupt can be registered per device. Call
+ *       pcf8574_unregister_interrupt() before registering a new one.
+ *
+ * @param dev Device handle
+ * @param int_gpio_num Host GPIO connected to the PCF8574 INT pin
+ * @param callback Function to call on interrupt (runs in ISR context)
+ * @param arg User argument passed to the callback
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev or callback is NULL
+ *      - ESP_ERR_INVALID_STATE if an interrupt is already registered
+ *      - ESP_FAIL on GPIO configuration error
+ */
+esp_err_t pcf8574_register_interrupt(pcf8574_handle_t dev, gpio_num_t int_gpio_num,
+                                     pcf8574_int_cb_t callback, void *arg);
+
+/**
+ * @brief Unregister the interrupt handler and release the host GPIO ISR.
+ *
+ * @param dev Device handle
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev is NULL
+ *      - ESP_ERR_INVALID_STATE if no interrupt was registered
+ */
+esp_err_t pcf8574_unregister_interrupt(pcf8574_handle_t dev);
 
 #ifdef __cplusplus
 }

--- a/components/pcf8574/include/pcf8574.h
+++ b/components/pcf8574/include/pcf8574.h
@@ -1,0 +1,28 @@
+/**
+ * @file
+ * @brief ESP BSP: Generic
+ */
+
+#pragma once
+
+#include "sdkconfig.h"
+#include "i2c_bus.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PCF8574_I2C_ADDR_DEFAULT 0x20
+
+// PCF8574 I2C Registers
+#define PCF8574_REG_INPUT 0x00
+#define PCF8574_REG_OUTPUT 0x01
+#define PCF8574_REG_POLARITY 0x02
+#define PCF8574_REG_CONFIG 0x03
+
+typedef void *pcf8574_handle_t;
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/pcf8574/include/pcf8574.h
+++ b/components/pcf8574/include/pcf8574.h
@@ -1,10 +1,12 @@
 /**
  * @file
- * @brief ESP BSP: Generic
+ * @brief PCF8574 I2C GPIO Expander Driver
  */
 
 #pragma once
 
+#include <stdint.h>
+#include "esp_err.h"
 #include "sdkconfig.h"
 #include "i2c_bus.h"
 
@@ -14,16 +16,52 @@ extern "C" {
 
 #define PCF8574_I2C_ADDR_DEFAULT 0x20
 
+/**
+ * @brief PCF8574 device handle type (opaque pointer)
+ */
 typedef void *pcf8574_handle_t;
-typedef struct {
-    i2c_bus_device_handle_t i2c_dev;
-    uint8_t dev_addr;
-} pcf8574_device_t;
 
-esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data);
-esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data);
+/**
+ * @brief Create and initialize a PCF8574 device on the given I2C bus.
+ *
+ * @param bus I2C bus handle
+ * @param dev_addr 7-bit I2C device address
+ * @return pcf8574_handle_t Device handle on success, NULL on failure
+ */
 pcf8574_handle_t pcf8574_create(i2c_bus_handle_t bus, uint8_t dev_addr);
+
+/**
+ * @brief Delete a PCF8574 device and free associated resources.
+ *
+ * @param[in,out] dev Pointer to the device handle. Will be set to NULL on success.
+ * @return
+ *      - ESP_OK on success
+ */
 esp_err_t pcf8574_delete(pcf8574_handle_t *dev);
+
+/**
+ * @brief Read the current 8-bit pin state from the PCF8574.
+ *
+ * @param dev Device handle
+ * @param[out] data Pointer to store the read byte
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev or data is NULL
+ *      - ESP_FAIL on I2C read error
+ */
+esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data);
+
+/**
+ * @brief Write an 8-bit value to the PCF8574 output pins.
+ *
+ * @param dev Device handle
+ * @param data The byte to write to the output pins
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG if dev is NULL
+ *      - ESP_FAIL on I2C write error
+ */
+esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data);
 
 #ifdef __cplusplus
 }

--- a/components/pcf8574/include/pcf8574.h
+++ b/components/pcf8574/include/pcf8574.h
@@ -14,12 +14,6 @@ extern "C" {
 
 #define PCF8574_I2C_ADDR_DEFAULT 0x20
 
-// PCF8574 I2C Registers
-#define PCF8574_REG_INPUT 0x00
-#define PCF8574_REG_OUTPUT 0x01
-#define PCF8574_REG_POLARITY 0x02
-#define PCF8574_REG_CONFIG 0x03
-
 typedef void *pcf8574_handle_t;
 typedef struct {
     i2c_bus_device_handle_t i2c_dev;

--- a/components/pcf8574/include/pcf8574.h
+++ b/components/pcf8574/include/pcf8574.h
@@ -21,7 +21,15 @@ extern "C" {
 #define PCF8574_REG_CONFIG 0x03
 
 typedef void *pcf8574_handle_t;
+typedef struct {
+    i2c_bus_device_handle_t i2c_dev;
+    uint8_t dev_addr;
+} pcf8574_device_t;
 
+esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data);
+esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data);
+pcf8574_handle_t pcf8574_create(i2c_bus_handle_t bus, uint8_t dev_addr);
+esp_err_t pcf8574_delete(pcf8574_handle_t *dev);
 
 #ifdef __cplusplus
 }

--- a/components/pcf8574/src/pcf8574.c
+++ b/components/pcf8574/src/pcf8574.c
@@ -66,7 +66,7 @@ esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data)
     }
 
     pcf8574_device_t *device = (pcf8574_device_t *)dev;
-    esp_err_t ret = i2c_bus_write_byte(device->i2c_dev, PCF8574_REG_OUTPUT, data);
+    esp_err_t ret = i2c_bus_write_bytes(device->i2c_dev, &data, 1);
     if (ret != ESP_OK) {
         return ESP_FAIL;
     }

--- a/components/pcf8574/src/pcf8574.c
+++ b/components/pcf8574/src/pcf8574.c
@@ -1,0 +1,67 @@
+/* HOPE Badge BSP
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "pcf8574.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+static const char *TAG = "PCF8574";
+
+typedef struct {
+    i2c_bus_device_handle_t i2c_dev;
+    uint8_t dev_addr;
+} pcf8574_device_t;
+
+pcf8574_handle_t pcf8574_create(i2c_bus_handle_t bus, uint8_t dev_addr)
+{
+    pcf8574_device_t *dev = (pcf8574_device_t *)calloc(1, sizeof(pcf8574_device_t));
+    dev->i2c_dev = i2c_bus_device_create(bus, dev_addr, i2c_bus_get_current_clk_speed(bus));
+    if (dev->i2c_dev == NULL) {
+        free(dev);
+        return NULL;
+    }
+    dev->dev_addr = dev_addr;
+    return (pcf8574_handle_t)(dev);
+}
+
+esp_err_t pcf8574_delete(pcf8574_handle_t *dev)
+{
+    if (*dev == NULL) {
+        return ESP_OK;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)(*dev);
+    i2c_bus_device_delete(&device->i2c_dev);
+    free(device);
+    *dev = NULL;
+    return ESP_OK;
+}
+
+esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data)
+{
+    if (dev == NULL || data == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data)
+{
+    if (dev == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return ESP_OK;
+}

--- a/components/pcf8574/src/pcf8574.c
+++ b/components/pcf8574/src/pcf8574.c
@@ -6,9 +6,12 @@
    software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
    CONDITIONS OF ANY KIND, either express or implied.
 */
+#include <stdlib.h>
+
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "driver/gpio.h"
 
 #include "pcf8574.h"
 
@@ -18,9 +21,38 @@ static const char *TAG = "pcf8574";
  * @brief Internal device structure for PCF8574
  */
 typedef struct {
-    i2c_bus_device_handle_t i2c_dev;
-    uint8_t dev_addr;
+    i2c_bus_device_handle_t i2c_dev;    /*!< I2C device handle */
+    uint8_t dev_addr;                    /*!< 7-bit I2C address */
+    uint8_t output_cache;                /*!< Cached output latch state */
+    uint8_t input_mask;                  /*!< Direction mask: 1 = input, 0 = output */
+    gpio_num_t int_gpio;                 /*!< Host GPIO for INT pin, or GPIO_NUM_NC */
+    pcf8574_int_cb_t int_cb;             /*!< User interrupt callback */
+    void *int_cb_arg;                    /*!< User interrupt callback argument */
 } pcf8574_device_t;
+
+/* -------------------------------------------------------------------------- */
+/*  Internal helpers                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Write the effective output value (cache merged with input mask).
+ *
+ * Input pins are always driven HIGH (weak pull-up) regardless of cache.
+ */
+static esp_err_t pcf8574_flush(pcf8574_device_t *device)
+{
+    uint8_t value = device->output_cache | device->input_mask;
+    return i2c_bus_write_byte(device->i2c_dev, NULL_I2C_MEM_ADDR, value);
+}
+
+static inline bool pcf8574_pin_valid(uint8_t pin)
+{
+    return pin < PCF8574_PIN_COUNT;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Lifecycle                                                                 */
+/* -------------------------------------------------------------------------- */
 
 pcf8574_handle_t pcf8574_create(i2c_bus_handle_t bus, uint8_t dev_addr)
 {
@@ -36,22 +68,38 @@ pcf8574_handle_t pcf8574_create(i2c_bus_handle_t bus, uint8_t dev_addr)
         return NULL;
     }
     dev->dev_addr = dev_addr;
+    dev->output_cache = 0xFF;   /* Power-on default: all pins HIGH */
+    dev->input_mask = 0xFF;     /* Assume all pins are inputs initially */
+    dev->int_gpio = GPIO_NUM_NC;
+    dev->int_cb = NULL;
+    dev->int_cb_arg = NULL;
+
     ESP_LOGD(TAG, "PCF8574 created at address 0x%02X", dev_addr);
     return (pcf8574_handle_t)(dev);
 }
 
 esp_err_t pcf8574_delete(pcf8574_handle_t *dev)
 {
-    if (*dev == NULL) {
+    if (dev == NULL || *dev == NULL) {
         return ESP_OK;
     }
 
     pcf8574_device_t *device = (pcf8574_device_t *)(*dev);
+
+    /* Clean up interrupt if registered */
+    if (device->int_gpio != GPIO_NUM_NC) {
+        pcf8574_unregister_interrupt(*dev);
+    }
+
     i2c_bus_device_delete(&device->i2c_dev);
     free(device);
     *dev = NULL;
     return ESP_OK;
 }
+
+/* -------------------------------------------------------------------------- */
+/*  Full-byte I/O                                                             */
+/* -------------------------------------------------------------------------- */
 
 esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data)
 {
@@ -70,5 +118,170 @@ esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data)
     }
 
     pcf8574_device_t *device = (pcf8574_device_t *)dev;
-    return i2c_bus_write_byte(device->i2c_dev, NULL_I2C_MEM_ADDR, data);
+    device->output_cache = data;
+    return pcf8574_flush(device);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Pin direction                                                             */
+/* -------------------------------------------------------------------------- */
+
+esp_err_t pcf8574_set_direction(pcf8574_handle_t dev, uint8_t input_mask)
+{
+    if (dev == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+    device->input_mask = input_mask;
+    return pcf8574_flush(device);
+}
+
+esp_err_t pcf8574_get_direction(pcf8574_handle_t dev, uint8_t *input_mask)
+{
+    if (dev == NULL || input_mask == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+    *input_mask = device->input_mask;
+    return ESP_OK;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Individual pin operations                                                 */
+/* -------------------------------------------------------------------------- */
+
+esp_err_t pcf8574_set_pin(pcf8574_handle_t dev, uint8_t pin)
+{
+    if (dev == NULL || !pcf8574_pin_valid(pin)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+    device->output_cache |= (1 << pin);
+    return pcf8574_flush(device);
+}
+
+esp_err_t pcf8574_clear_pin(pcf8574_handle_t dev, uint8_t pin)
+{
+    if (dev == NULL || !pcf8574_pin_valid(pin)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+    device->output_cache &= ~(1 << pin);
+    return pcf8574_flush(device);
+}
+
+esp_err_t pcf8574_toggle_pin(pcf8574_handle_t dev, uint8_t pin)
+{
+    if (dev == NULL || !pcf8574_pin_valid(pin)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+    device->output_cache ^= (1 << pin);
+    return pcf8574_flush(device);
+}
+
+esp_err_t pcf8574_read_pin(pcf8574_handle_t dev, uint8_t pin, uint8_t *level)
+{
+    if (dev == NULL || level == NULL || !pcf8574_pin_valid(pin)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    uint8_t port_data = 0;
+    esp_err_t ret = pcf8574_read(dev, &port_data);
+    if (ret == ESP_OK) {
+        *level = (port_data >> pin) & 0x01;
+    }
+    return ret;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Interrupt support                                                         */
+/* -------------------------------------------------------------------------- */
+
+static void IRAM_ATTR pcf8574_isr_handler(void *arg)
+{
+    pcf8574_device_t *device = (pcf8574_device_t *)arg;
+    if (device->int_cb) {
+        device->int_cb(device->int_cb_arg);
+    }
+}
+
+esp_err_t pcf8574_register_interrupt(pcf8574_handle_t dev, gpio_num_t int_gpio_num,
+                                     pcf8574_int_cb_t callback, void *arg)
+{
+    if (dev == NULL || callback == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+
+    if (device->int_gpio != GPIO_NUM_NC) {
+        ESP_LOGE(TAG, "Interrupt already registered on GPIO %d", device->int_gpio);
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Configure the host GPIO for falling edge (PCF8574 INT is active-LOW, open-drain) */
+    gpio_config_t io_conf = {
+        .pin_bit_mask = (1ULL << int_gpio_num),
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_NEGEDGE,
+    };
+
+    esp_err_t ret = gpio_config(&io_conf);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to configure INT GPIO %d: %s", int_gpio_num, esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = gpio_install_isr_service(0);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        /* ESP_ERR_INVALID_STATE means ISR service already installed — that's fine */
+        ESP_LOGE(TAG, "Failed to install GPIO ISR service: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    device->int_cb = callback;
+    device->int_cb_arg = arg;
+
+    ret = gpio_isr_handler_add(int_gpio_num, pcf8574_isr_handler, device);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to add ISR handler for GPIO %d: %s", int_gpio_num, esp_err_to_name(ret));
+        device->int_cb = NULL;
+        device->int_cb_arg = NULL;
+        return ret;
+    }
+
+    device->int_gpio = int_gpio_num;
+    ESP_LOGD(TAG, "Interrupt registered on GPIO %d", int_gpio_num);
+    return ESP_OK;
+}
+
+esp_err_t pcf8574_unregister_interrupt(pcf8574_handle_t dev)
+{
+    if (dev == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+
+    if (device->int_gpio == GPIO_NUM_NC) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    gpio_isr_handler_remove(device->int_gpio);
+    gpio_reset_pin(device->int_gpio);
+
+    device->int_gpio = GPIO_NUM_NC;
+    device->int_cb = NULL;
+    device->int_cb_arg = NULL;
+
+    ESP_LOGD(TAG, "Interrupt unregistered");
+    return ESP_OK;
 }

--- a/components/pcf8574/src/pcf8574.c
+++ b/components/pcf8574/src/pcf8574.c
@@ -48,15 +48,16 @@ esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data)
         return ESP_ERR_INVALID_ARG;
     }
 
-    uint8_t result = 0;
     pcf8574_device_t *device = (pcf8574_device_t *)dev;
-    esp_err_t ret = i2c_bus_read_bytes(device->i2c_dev, &result, 1);
+
+    uint8_t buf = 0x00;
+    esp_err_t ret = i2c_bus_read_bytes(device->i2c_dev, 0x00, 1, &buf);  // 0x00 is a dummy register
     if (ret != ESP_OK) {
         return ESP_FAIL;
     }
-    *data = result;
 
-    return ESP_OK;
+    *data = buf;
+    return ret;
 }
 
 esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data)
@@ -66,10 +67,5 @@ esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data)
     }
 
     pcf8574_device_t *device = (pcf8574_device_t *)dev;
-    esp_err_t ret = i2c_bus_write_bytes(device->i2c_dev, &data, 1);
-    if (ret != ESP_OK) {
-        return ESP_FAIL;
-    }
-
-    return ESP_OK;
+    return i2c_bus_write_byte(device->i2c_dev, 0x00, data);
 }

--- a/components/pcf8574/src/pcf8574.c
+++ b/components/pcf8574/src/pcf8574.c
@@ -50,7 +50,7 @@ esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data)
 
     uint8_t result = 0;
     pcf8574_device_t *device = (pcf8574_device_t *)dev;
-    esp_err_t ret = i2c_bus_read_byte(device->i2c_dev, PCF8574_REG_INPUT, &result);
+    esp_err_t ret = i2c_bus_read_bytes(device->i2c_dev, &result, 1);
     if (ret != ESP_OK) {
         return ESP_FAIL;
     }

--- a/components/pcf8574/src/pcf8574.c
+++ b/components/pcf8574/src/pcf8574.c
@@ -16,13 +16,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-static const char *TAG = "PCF8574";
-
-typedef struct {
-    i2c_bus_device_handle_t i2c_dev;
-    uint8_t dev_addr;
-} pcf8574_device_t;
-
 pcf8574_handle_t pcf8574_create(i2c_bus_handle_t bus, uint8_t dev_addr)
 {
     pcf8574_device_t *dev = (pcf8574_device_t *)calloc(1, sizeof(pcf8574_device_t));
@@ -48,11 +41,20 @@ esp_err_t pcf8574_delete(pcf8574_handle_t *dev)
     return ESP_OK;
 }
 
+
 esp_err_t pcf8574_read(pcf8574_handle_t dev, uint8_t *data)
 {
     if (dev == NULL || data == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
+
+    uint8_t result = 0;
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+    esp_err_t ret = i2c_bus_read_byte(device->i2c_dev, PCF8574_REG_INPUT, &result);
+    if (ret != ESP_OK) {
+        return ESP_FAIL;
+    }
+    *data = result;
 
     return ESP_OK;
 }
@@ -61,6 +63,12 @@ esp_err_t pcf8574_write(pcf8574_handle_t dev, uint8_t data)
 {
     if (dev == NULL) {
         return ESP_ERR_INVALID_ARG;
+    }
+
+    pcf8574_device_t *device = (pcf8574_device_t *)dev;
+    esp_err_t ret = i2c_bus_write_byte(device->i2c_dev, PCF8574_REG_OUTPUT, data);
+    if (ret != ESP_OK) {
+        return ESP_FAIL;
     }
 
     return ESP_OK;

--- a/examples/pcf8574_input/CMakeLists.txt
+++ b/examples/pcf8574_input/CMakeLists.txt
@@ -1,0 +1,9 @@
+# For more information about build system see
+# https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+set(COMPONENTS main)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(pcf8574_input)

--- a/examples/pcf8574_input/README.md
+++ b/examples/pcf8574_input/README.md
@@ -1,0 +1,77 @@
+# PCF8574 Input Reading Example
+
+This example demonstrates how to use the **PCF8574** I²C I/O expander component to read input pins, using both **polling** and **interrupt-driven** approaches.
+
+## Overview
+
+The PCF8574 has 8 quasi-bidirectional I/O pins. Pins configured as inputs are held HIGH by a weak internal pull-up (~100 µA). When a button or switch pulls a pin LOW, the change is detected either by periodic polling or via the PCF8574 INT output.
+
+This example configures:
+- **P1, P2, P3** as inputs (buttons to GND)
+- **P0, P4–P7** as outputs
+- P0 is set HIGH as a demo
+
+## Hardware Setup
+
+```
+                 ┌─────────────┐
+           P0 ── │ PCF8574     │ ── VCC (3.3V)
+   BTN1 ── P1 ── │             │ ── GND
+   BTN2 ── P2 ── │  I2C Addr:  │ ── SDA (GPIO 20)
+   BTN3 ── P3 ── │  0x20       │ ── SCL (GPIO 21)
+           P4 ── │             │ ── INT (optional → GPIO 4)
+           P5 ── │             │
+           P6 ── │             │
+           P7 ── │             │
+                 └─────────────┘
+```
+
+- **Buttons**: Connect between PCF8574 input pins (P1, P2, P3) and **GND**. No external pull-up is needed — the PCF8574 has a weak internal pull-up.
+- **INT pin** (optional): Connect to a host GPIO (e.g., GPIO 4) with an external pull-up resistor (4.7 kΩ to VCC), since INT is open-drain.
+
+## Two Approaches
+
+### 1. Polling (default)
+
+Reads all PCF8574 pins every 500 ms and logs changes:
+
+```
+I (1234) pcf8574_input: Port read: 0xFC (bin: 11111100)
+I (1234) pcf8574_input:   P1 = 0 (pressed)
+I (1234) pcf8574_input:   P2 = 0 (pressed)
+I (1234) pcf8574_input:   P3 = 1 (released)
+```
+
+### 2. Interrupt-driven
+
+Reacts immediately when any input pin changes. To enable this mode, uncomment `#define EXAMPLE_USE_INTERRUPT` in `main.c` and set `PCF8574_INT_GPIO` to the host GPIO connected to the PCF8574 INT pin.
+
+```
+I (5678) pcf8574_input: [INT] Port read: 0xFA
+I (5678) pcf8574_input: [INT]   P1 = 1 (released)
+I (5678) pcf8574_input: [INT]   P2 = 0 (pressed)
+I (5678) pcf8574_input: [INT]   P3 = 1 (released)
+```
+
+## Build and Flash
+
+```bash
+cd examples/pcf8574_input
+idf.py build
+idf.py -p /dev/ttyUSB0 flash monitor
+```
+
+## Key API Calls Demonstrated
+
+| Function                      | Purpose                                       |
+|-------------------------------|-----------------------------------------------|
+| `pcf8574_create()`            | Create the device handle                      |
+| `pcf8574_set_direction()`     | Set which pins are inputs vs outputs          |
+| `pcf8574_read()`              | Read all 8 pins at once                       |
+| `pcf8574_read_pin()`          | Read a single pin                             |
+| `pcf8574_set_pin()`           | Set an individual output pin HIGH             |
+| `pcf8574_register_interrupt()`| Register an ISR for pin-change events         |
+
+## License
+
+This example is in the Public Domain (or CC0 licensed, at your option).

--- a/examples/pcf8574_input/main/CMakeLists.txt
+++ b/examples/pcf8574_input/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "main.c"
+                    INCLUDE_DIRS ".")

--- a/examples/pcf8574_input/main/idf_component.yml
+++ b/examples/pcf8574_input/main/idf_component.yml
@@ -1,0 +1,6 @@
+description: PCF8574 input reading example
+
+dependencies:
+  hope-badge/hope-badge:
+    version: '*'
+    override_path: ../../../bsp/hope-badge

--- a/examples/pcf8574_input/main/main.c
+++ b/examples/pcf8574_input/main/main.c
@@ -1,0 +1,186 @@
+/* PCF8574 Input Reading Example
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include <stdio.h>
+#include "esp_err.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "bsp/bsp.h"
+#include "pcf8574.h"
+
+static const char *TAG = "pcf8574_input";
+
+/**
+ * PCF8574 pin assignment for this example:
+ *
+ *   P0 – output (directly driven)
+ *   P1 – input  (directly read, directly connected to pin/button)
+ *   P2 – input  (directly read, directly connected to pin/button)
+ *   P3 – input  (directly read, directly connected to pin/button)
+ *   P4 – output
+ *   P5 – output
+ *   P6 – output
+ *   P7 – output
+ *
+ * Input mask: 0x0E  (binary 00001110 → P1, P2, P3 are inputs)
+ *
+ * For input pins, the PCF8574 uses a weak internal pull-up (~100 µA).
+ * Connect buttons/switches between the input pin and GND.
+ * When pressed, the pin reads LOW (0). When released, the pull-up holds it HIGH (1).
+ */
+
+#define INPUT_MASK  0x0E    /* P1, P2, P3 as inputs */
+
+/*
+ * Example 1: Polling — read all inputs every 500 ms
+ */
+static void pcf8574_polling_task(void *arg)
+{
+    pcf8574_handle_t dev = (pcf8574_handle_t)arg;
+    uint8_t data = 0;
+    uint8_t prev_data = 0xFF;
+
+    ESP_LOGI(TAG, "Polling task started — reading PCF8574 inputs every 500 ms");
+
+    while (1) {
+        esp_err_t ret = pcf8574_read(dev, &data);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to read PCF8574: %s", esp_err_to_name(ret));
+        } else {
+            /* Only log when something changed */
+            if (data != prev_data) {
+                ESP_LOGI(TAG, "Port read: 0x%02X (bin: %c%c%c%c%c%c%c%c)",
+                         data,
+                         (data & 0x80) ? '1' : '0',
+                         (data & 0x40) ? '1' : '0',
+                         (data & 0x20) ? '1' : '0',
+                         (data & 0x10) ? '1' : '0',
+                         (data & 0x08) ? '1' : '0',
+                         (data & 0x04) ? '1' : '0',
+                         (data & 0x02) ? '1' : '0',
+                         (data & 0x01) ? '1' : '0');
+
+                /* Read individual input pins */
+                for (uint8_t pin = 1; pin <= 3; pin++) {
+                    uint8_t level = 0;
+                    pcf8574_read_pin(dev, pin, &level);
+                    ESP_LOGI(TAG, "  P%d = %d %s", pin, level,
+                             level == 0 ? "(pressed)" : "(released)");
+                }
+                prev_data = data;
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+}
+
+/*
+ * Example 2: Interrupt-driven — react immediately to pin changes
+ *
+ * The PCF8574 INT pin is active-LOW and fires on any input change.
+ * This ISR callback notifies a task that performs the actual I2C read.
+ */
+static TaskHandle_t int_task_handle = NULL;
+
+static void IRAM_ATTR pcf8574_int_callback(void *arg)
+{
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    if (int_task_handle) {
+        vTaskNotifyGiveFromISR(int_task_handle, &xHigherPriorityTaskWoken);
+        portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+    }
+}
+
+static void pcf8574_interrupt_task(void *arg)
+{
+    pcf8574_handle_t dev = (pcf8574_handle_t)arg;
+    uint8_t data = 0;
+
+    ESP_LOGI(TAG, "Interrupt task started — waiting for PCF8574 pin changes");
+
+    while (1) {
+        /* Block until the ISR signals a pin change */
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+
+        esp_err_t ret = pcf8574_read(dev, &data);
+        if (ret == ESP_OK) {
+            ESP_LOGI(TAG, "[INT] Port read: 0x%02X", data);
+            for (uint8_t pin = 1; pin <= 3; pin++) {
+                uint8_t level = (data >> pin) & 0x01;
+                ESP_LOGI(TAG, "[INT]   P%d = %d %s", pin, level,
+                         level == 0 ? "(pressed)" : "(released)");
+            }
+        } else {
+            ESP_LOGE(TAG, "[INT] Failed to read PCF8574: %s", esp_err_to_name(ret));
+        }
+    }
+}
+
+void app_main(void)
+{
+    ESP_LOGI(TAG, "PCF8574 Input Reading Example");
+
+    /* Initialize the BSP (sets up I2C bus, etc.) */
+    ESP_ERROR_CHECK(bsp_init());
+
+    /*
+     * Create the PCF8574 device.
+     * The BSP already creates one internally, but here we show standalone usage.
+     */
+    extern i2c_bus_handle_t i2c_bus; /* Exposed by the BSP for reuse */
+
+    pcf8574_handle_t pcf_dev = pcf8574_create(i2c_bus, PCF8574_I2C_ADDR_DEFAULT);
+    if (pcf_dev == NULL) {
+        ESP_LOGE(TAG, "Failed to create PCF8574 device");
+        return;
+    }
+
+    /*
+     * Configure pin directions:
+     *   INPUT_MASK = 0x0E → P1, P2, P3 are inputs (held HIGH by weak pull-up)
+     *   Remaining pins are outputs.
+     */
+    ESP_ERROR_CHECK(pcf8574_set_direction(pcf_dev, INPUT_MASK));
+    ESP_LOGI(TAG, "Direction set: input_mask=0x%02X (P1, P2, P3 = input)", INPUT_MASK);
+
+    /* Set output pin P0 HIGH as a demo */
+    ESP_ERROR_CHECK(pcf8574_set_pin(pcf_dev, 0));
+    ESP_LOGI(TAG, "P0 set HIGH");
+
+    /*
+     * Choose one of the two approaches below.
+     * Uncomment EXAMPLE_USE_INTERRUPT to use interrupt mode instead of polling.
+     */
+/* #define EXAMPLE_USE_INTERRUPT */
+
+#ifdef EXAMPLE_USE_INTERRUPT
+    /*
+     * Interrupt-driven approach
+     *
+     * Connect the PCF8574 INT pin to a host GPIO. The BSP does not define
+     * a default INT pin, so set this to your wiring. For example, GPIO 4:
+     */
+    #define PCF8574_INT_GPIO  GPIO_NUM_4
+
+    /* Create the task first so the handle is valid before the ISR fires */
+    xTaskCreate(pcf8574_interrupt_task, "pcf8574_int", 3072, pcf_dev, 10, &int_task_handle);
+
+    ESP_ERROR_CHECK(pcf8574_register_interrupt(pcf_dev, PCF8574_INT_GPIO,
+                                               pcf8574_int_callback, NULL));
+    ESP_LOGI(TAG, "Interrupt registered on GPIO %d — press buttons to see events", PCF8574_INT_GPIO);
+#else
+    /*
+     * Polling approach — read inputs periodically
+     */
+    xTaskCreate(pcf8574_polling_task, "pcf8574_poll", 3072, pcf_dev, 5, NULL);
+#endif
+
+    ESP_LOGI(TAG, "Example running. Press buttons connected to P1, P2, P3.");
+}

--- a/examples/pcf8574_input/sdkconfig.defaults
+++ b/examples/pcf8574_input/sdkconfig.defaults
@@ -1,0 +1,5 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="esp32c3"
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y


### PR DESCRIPTION
This PR introduces a new driver component for the PCF8574, an 8-bit I²C I/O expander, integrated into the HOPE Badge BSP. It provides a lightweight and reusable interface using the i2c_bus abstraction layer, allowing easy GPIO expansion over I²C.

Component Details

    Path: components/pcf8574/
    Interface: Uses i2c_bus from esp-iot-solution